### PR TITLE
Update sigwidget2.py to import matplotlib 1.5.0 libs

### DIFF
--- a/ui/sigwidget2.py
+++ b/ui/sigwidget2.py
@@ -41,7 +41,10 @@ try:
 except:
 	pass
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+try:
+	from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+except ImportError:
+	from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 # Import Figure
 from matplotlib.figure import Figure
 


### PR DESCRIPTION
Imports NavigationToolbar2QTAgg (<1.5.0) but when that fails imports NavigationToolbar2QT (>=1.5.0)