### PR TITLE
Update scpdock.py

### DIFF
--- a/dock/scpdock.py
+++ b/dock/scpdock.py
@@ -2523,7 +2523,7 @@ class SCPDock:
 		except:
 			pass
 		clr = cfg.QtGuiSCP.QColor(cfg.ROIClrVal)
-		rT = 255 - cfg.ROITrnspVal * 255 / 100
+		rT = 255 - cfg.ROITrnspVal * 255 // 100
 		clr.setAlpha(rT)
 		f = cfg.utls.getFeaturebyID(sourceLayer, ID)
 		cfg.rbbrBndPol = cfg.qgisGuiSCP.QgsHighlight(cfg.cnvs, f.geometry(), sourceLayer)


### PR DESCRIPTION
corrected an issue in line 2527, in addHighlightPolygon
clr.setAlpha(rT)
TypeError: setAlpha(self, int): argument 1 has unexpected type 'float'


the issue was in the previous line:

rT = 255 - cfg.ROITrnspVal * 255 / 100

returns a float, i returned an integer
