### PR TITLE
Update clipmultiplerasters.py

### DIFF
--- a/maininterface/clipmultiplerasters.py
+++ b/maininterface/clipmultiplerasters.py
@@ -222,7 +222,7 @@ class ClipMultipleRasters:
 		# using coordinates
 		if uS == 0 and len(UX) > 0 and len(UY) > 0 and len(LX) > 0 and len(LY) > 0:
 			for l in rT:
-				f = oD + '/' + outputName + '_' + cfg.utls.fileNameNoExt(l) + '.tif'
+				f = oD + '/' + outputName.replace('.jp2', '') + '_' + cfg.utls.fileNameNoExt(l) + '.tif'
 				bbList = [l]
 				pCrs = cfg.utls.getQGISCrs()
 				rEPSG = cfg.osrSCP.SpatialReference()

--- a/maininterface/clipmultiplerasters.py
+++ b/maininterface/clipmultiplerasters.py
@@ -222,7 +222,7 @@ class ClipMultipleRasters:
 		# using coordinates
 		if uS == 0 and len(UX) > 0 and len(UY) > 0 and len(LX) > 0 and len(LY) > 0:
 			for l in rT:
-				f = oD + '/' + outputName.replace('.jp2', '') + '_' + cfg.utls.fileNameNoExt(l) + '.tif'
+				f = oD + '/' + outputName + '_' + cfg.utls.fileNameNoExt(l).replace('.jp2', '') + '.tif'
 				bbList = [l]
 				pCrs = cfg.utls.getQGISCrs()
 				rEPSG = cfg.osrSCP.SpatialReference()


### PR DESCRIPTION
In the 'Clip multiple rasters', I experienced the results like this:
clip_T52SCH_A029344_20221019T022253_B02.jp2.tif
clip_T52SCH_A029344_20221019T022253_B03.jp2.tif
...
For your reference, I downloaded Sentinel-2 images by using SCP 'Download products'.

The next step was Preprocessing following your [Land Cover Classification tutorial](https://fromgistors.blogspot.com/2020/10/land-cover-classification-scp-7.html).
However, the Preprocessing functions can't read the bands normally because of the filename(*.jpg.tif), so I suggest to check the name about the case.
```
# As-Is
f = oD + '/' + outputName + '_' + cfg.utls.fileNameNoExt(l) + '.tif'
# To-Be
f = oD + '/' + outputName + '_' + cfg.utls.fileNameNoExt(l).replace('.jp2', '') + '.tif' 
```