### PR TITLE
Show a "Critical" level message when the remotior_sensus module is not installed

### DIFF
--- a/semiautomaticclassificationplugin.py
+++ b/semiautomaticclassificationplugin.py
@@ -85,7 +85,7 @@ except Exception as error:
             'Error. Please, install the required Python library '
             'remotior_sensus'
         ),
-        level=Qgis.Info
+        level=Qgis.Critical
     )
 
 try:


### PR DESCRIPTION
I think it's more appropriate than an "Info" level message. Alternatively, It could be used a "Warning" level message.