### PR TITLE
Fix remotior-sensus package name in warning message

### DIFF
--- a/semiautomaticclassificationplugin.py
+++ b/semiautomaticclassificationplugin.py
@@ -91,10 +91,10 @@ except Exception as error:
         qgis_utils.iface.messageBar().pushMessage(
             'Semi-Automatic Classification Plugin', QApplication.translate(
                 'semiautomaticclassificationplugin',
-                'Warning. Python library remotior_sensus was not found and was'
+                'Warning. Python library remotior-sensus was not found and was'
                 ' automatically downloaded, but SCP may not work properly.'
                 'Please, install the required Python library '
-                'remotior_sensus following the user manual.'
+                'remotior-sensus following the user manual.'
             ), level=Qgis.Warning, duration=10
         )
     except Exception as error:
@@ -137,10 +137,10 @@ except Exception as error:
             qgis_utils.iface.messageBar().pushMessage(
                 'Semi-Automatic Classification Plugin', QApplication.translate(
                     'semiautomaticclassificationplugin',
-                    'Warning. Python library remotior_sensus was not found '
+                    'Warning. Python library remotior-sensus was not found '
                     'and was automatically downloaded, but SCP may not work '
                     'properly. Please, install the required Python library '
-                    'remotior_sensus following the user manual.'
+                    'remotior-sensus following the user manual.'
                 ), level=Qgis.Warning, duration=10
             )
         except Exception as error:


### PR DESCRIPTION
In the user manual there is no mention of `remotior_sensus`.

https://semiautomaticclassificationmanual.readthedocs.io/en/latest/search.html?q=remotior_sensus&check_keywords=yes&area=default