### PR TITLE
Fix classification output mismatch between preview and final raster

### DIFF
--- a/interface/classification_tab.py
+++ b/interface/classification_tab.py
@@ -393,7 +393,7 @@ def run_classifier(
     cfg.ui_utils.add_progress_bar()
     # classification
     if preview_point is None:
-        bandset = bandset_number
+        bandset = deepcopy(bandset_x)
         finish_sound = True
         smtp = str(__name__)
     # classification preview


### PR DESCRIPTION
Hello,

I am currently working on my diploma thesis titled “Expansion of the Semi-Automatic Classification Plugin with the ability to remove outliers from the training input.” One of the tasks was to identify and fix a bug in the Semi-Automatic Classification Plugin.

During the classification process, the generated output raster was incorrect, while the Classification Preview tool provided by SCP produced correct results.

After analyzing the classification workflow in the source code, I found that in the raster generation method the bandset object had a different value compared to the one used during Classification Preview, which caused incorrect raster generation.

This pull request fixes the issue by correcting the way the bandset is copied and passed during raster generation, ensuring that the final classification raster matches the preview result.

This behavior appears to be the same issue described in issue #420  , where the classification preview works correctly but the final output raster differs from the preview.